### PR TITLE
헤로쿠에 배포하기 - DB 변경 (ClearDB -> JawsDB)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,6 +42,6 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always


### PR DESCRIPTION
Deploy 과정에서 DB오류가 발생해 원인을 조사해보니 ClearDB의 기본 MySQL 버전이 `5.6`으로, 사용중인 `8.0`과 버전상 큰 차이가 있는 것으로 확인됐다. 이에 대안으로 JawsDB를 사용하기로 함.

This fixes #42

* https://devcenter.heroku.com/articles/cleardb
* https://devcenter.heroku.com/articles/jawsdb