### PR TITLE
equals()에서 필드 접근을 getter로 바꾸기

### DIFF
--- a/src/main/java/com/practice/board/domain/Article.java
+++ b/src/main/java/com/practice/board/domain/Article.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -37,7 +38,7 @@ public class Article extends Creatable {
 
     @Setter
     @JoinColumn(name = "userId")
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     private UserAccount userAccount; // 유저
 
     @Setter
@@ -74,14 +75,14 @@ public class Article extends Creatable {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof Article article)) {
+        if (!(o instanceof Article that)) {
             return false;
         }
-        return id != null && id.equals(article.id);
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/practice/board/domain/ArticleComment.java
+++ b/src/main/java/com/practice/board/domain/ArticleComment.java
@@ -55,14 +55,14 @@ public class ArticleComment extends Creatable {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof ArticleComment articleComment)) {
+        if (!(o instanceof ArticleComment that)) {
             return false;
         }
-        return id != null && id.equals(articleComment.id);
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/practice/board/domain/UserAccount.java
+++ b/src/main/java/com/practice/board/domain/UserAccount.java
@@ -49,8 +49,12 @@ public class UserAccount extends Creatable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof UserAccount that)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof UserAccount that)) {
+            return false;
+        }
         return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 


### PR DESCRIPTION
이 pr은 엔티티의 equals(), hashcode()가 값 비교를 하기 위해 필드 직접 접근하는 것을 getter 접근으로 바꾼다.
프록시 객체를 사용하는 하이버네이트의 지연 로딩을 고려하여, 값 비교를 제대로 수행하지 못하는 일이 없도록 한다.

* 정리글: https://taemham.github.io/posts/SpringBoot_JpaAndEquals/

This closes #51 